### PR TITLE
WIP Add `Leak` to `Reuse` enum

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,12 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       ),
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "org.typelevel.keypool.KeyPool#KeyPoolConcrete.kpDestroy"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.typelevel.keypool.Managed.this"),
+      ProblemFilters
+        .exclude[IncompatibleMethTypeProblem]("org.typelevel.keypool.KeyPool#Builder.this"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.typelevel.keypool.KeyPool#Builder#Defaults.defaultReuseState"
       )
     )
   )

--- a/core/src/main/scala/org/typelevel/keypool/KeyPoolBuilder.scala
+++ b/core/src/main/scala/org/typelevel/keypool/KeyPoolBuilder.scala
@@ -94,7 +94,10 @@ final class KeyPoolBuilder[F[_]: Temporal, A, B] private (
       }
     } yield new KeyPool.KeyPoolConcrete(
       (a: A) => Resource.make[F, B](kpCreate(a))(kpDestroy),
-      kpDefaultReuseState,
+      kpDefaultReuseState match {
+        case Reusable.Reuse => Reusable2.Reuse
+        case Reusable.DontReuse => Reusable2.DontReuse
+      },
       kpMaxPerKey,
       kpMaxTotal,
       kpVar
@@ -118,6 +121,7 @@ object KeyPoolBuilder {
     Defaults.onReaperException[F]
   )
 
+  @deprecated
   private object Defaults {
     val defaultReuseState = Reusable.Reuse
     val idleTimeAllowedInPool = 30.seconds

--- a/core/src/main/scala/org/typelevel/keypool/Managed.scala
+++ b/core/src/main/scala/org/typelevel/keypool/Managed.scala
@@ -24,6 +24,8 @@ package org.typelevel.keypool
 import cats.Functor
 import cats.effect.kernel._
 
+import scala.annotation.nowarn
+
 /**
  * A managed Resource.
  *
@@ -33,7 +35,9 @@ import cats.effect.kernel._
 final class Managed[F[_], A] private[keypool] (
     val value: A,
     val isReused: Boolean,
-    val canBeReused: Ref[F, Reusable]
+    @deprecated
+    val canBeReused: Ref[F, Reusable],
+    val canBeReused2: Ref[F, Reusable2]
 )
 
 object Managed {
@@ -41,7 +45,8 @@ object Managed {
     def map[A, B](fa: Managed[F, A])(f: A => B): Managed[F, B] = new Managed[F, B](
       f(fa.value),
       fa.isReused,
-      fa.canBeReused
+      fa.canBeReused: @nowarn,
+      fa.canBeReused2
     )
   }
 }

--- a/core/src/main/scala/org/typelevel/keypool/Reusable.scala
+++ b/core/src/main/scala/org/typelevel/keypool/Reusable.scala
@@ -27,8 +27,17 @@ package org.typelevel.keypool
  * If it is Reuse then it will be attempted to place back in the pool, if it is in DontReuse the
  * resource will be shutdown.
  */
+@deprecated
 sealed trait Reusable
+@deprecated
 object Reusable {
   case object Reuse extends Reusable
   case object DontReuse extends Reusable
+}
+
+sealed trait Reusable2
+object Reusable2 {
+  case object Reuse extends Reusable2
+  case object DontReuse extends Reusable2
+  case object Leak extends Reusable2
 }


### PR DESCRIPTION
It's a bit of a lie. Actually, deprecates the old `Reuse` enum and in favor of `Reuse2` (bikeshed the name). And very nearly pulls it off, except for one constraint gotcha...