### PR TITLE
Downgrade to scala.js-1.4.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.3.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.4.0")
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.5")


### PR DESCRIPTION
We don't have a minor version to bump to before we shut down keypool-0.3.  Let's see if this works.  If not... I don't think it's _that_ awful to bump scala.js in an early-semver patch.

This should absolutely not propagate to main.