### PR TITLE
Do not allocate more resources than the `maxTotal`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,8 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       ),
       ProblemFilters
         .exclude[DirectMissingMethodProblem]("org.typelevel.keypool.KeyPoolBuilder.this"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("org.typelevel.keypool.KeyPool#Builder.this")
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("org.typelevel.keypool.KeyPool#Builder.this")
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,10 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       ),
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "org.typelevel.keypool.KeyPool#KeyPoolConcrete.kpDestroy"
-      )
+      ),
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("org.typelevel.keypool.KeyPoolBuilder.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("org.typelevel.keypool.KeyPool#Builder.this")
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -59,8 +59,7 @@ lazy val commonSettings = Seq(
   Test / parallelExecution := false,
   libraryDependencies ++= Seq(
     "org.typelevel" %%% "cats-core"           % catsV,
-    "org.typelevel" %%% "cats-effect-kernel"  % catsEffectV,
-    "org.typelevel" %%% "cats-effect-std"     % catsEffectV      % Test,
+    "org.typelevel" %%% "cats-effect-std"     % catsEffectV,
     "org.scalameta" %%% "munit"               % munitV           % Test,
     "org.typelevel" %%% "munit-cats-effect-3" % munitCatsEffectV % Test
   )

--- a/core/src/main/scala/org/typelevel/keypool/Pool.scala
+++ b/core/src/main/scala/org/typelevel/keypool/Pool.scala
@@ -74,6 +74,7 @@ object Pool {
       val kpRes: Resource[F, B],
       val kpDefaultReuseState: Reusable,
       val idleTimeAllowedInPool: Duration,
+      val kpMaxIdle: Int,
       val kpMaxTotal: Int,
       val onReaperException: Throwable => F[Unit]
   ) {
@@ -81,12 +82,14 @@ object Pool {
         kpRes: Resource[F, B] = this.kpRes,
         kpDefaultReuseState: Reusable = this.kpDefaultReuseState,
         idleTimeAllowedInPool: Duration = this.idleTimeAllowedInPool,
+        kpMaxIdle: Int = this.kpMaxIdle,
         kpMaxTotal: Int = this.kpMaxTotal,
         onReaperException: Throwable => F[Unit] = this.onReaperException
     ): Builder[F, B] = new Builder[F, B](
       kpRes,
       kpDefaultReuseState,
       idleTimeAllowedInPool,
+      kpMaxIdle,
       kpMaxTotal,
       onReaperException
     )
@@ -105,6 +108,9 @@ object Pool {
     def withIdleTimeAllowedInPool(duration: Duration) =
       copy(idleTimeAllowedInPool = duration)
 
+    def withMaxIdle(maxIdle: Int): Builder[F, B] =
+      copy(kpMaxIdle = maxIdle)
+
     def withMaxTotal(total: Int): Builder[F, B] =
       copy(kpMaxTotal = total)
 
@@ -117,6 +123,7 @@ object Pool {
         kpDefaultReuseState = kpDefaultReuseState,
         idleTimeAllowedInPool = idleTimeAllowedInPool,
         kpMaxPerKey = _ => kpMaxTotal,
+        kpMaxIdle = kpMaxIdle,
         kpMaxTotal = kpMaxTotal,
         onReaperException = onReaperException
       )
@@ -138,6 +145,7 @@ object Pool {
       res,
       Defaults.defaultReuseState,
       Defaults.idleTimeAllowedInPool,
+      Defaults.maxIdle,
       Defaults.maxTotal,
       Defaults.onReaperException[F]
     )
@@ -151,6 +159,7 @@ object Pool {
     private object Defaults {
       val defaultReuseState = Reusable.Reuse
       val idleTimeAllowedInPool = 30.seconds
+      val maxIdle = 100
       val maxTotal = 100
       def onReaperException[F[_]: Applicative] = { (t: Throwable) =>
         Function.const(Applicative[F].unit)(t)

--- a/core/src/test/scala/org/typelevel/keypool/KeyPoolSpec.scala
+++ b/core/src/test/scala/org/typelevel/keypool/KeyPoolSpec.scala
@@ -23,6 +23,7 @@ package org.typelevel.keypool
 
 import cats.syntax.all._
 import cats.effect._
+import cats.effect.std.CountDownLatch
 import scala.concurrent.duration._
 import munit.CatsEffectSuite
 import scala.concurrent.ExecutionContext
@@ -32,8 +33,6 @@ class KeypoolSpec extends CatsEffectSuite {
   override val munitExecutionContext: ExecutionContext = ExecutionContext.global
 
   test("Keep Resources marked to be kept") {
-    def nothing(ref: Ref[IO, Int]): IO[Unit] =
-      ref.get.void
     KeyPool
       .Builder(
         (i: Int) => Ref.of[IO, Int](i),
@@ -54,8 +53,6 @@ class KeypoolSpec extends CatsEffectSuite {
   }
 
   test("Delete Resources marked to be deleted") {
-    def nothing(ref: Ref[IO, Int]): IO[Unit] =
-      ref.get.void
     KeyPool
       .Builder(
         (i: Int) => Ref.of[IO, Int](i),
@@ -76,8 +73,6 @@ class KeypoolSpec extends CatsEffectSuite {
   }
 
   test("Delete Resource when pool is full") {
-    def nothing(ref: Ref[IO, Int]): IO[Unit] =
-      ref.get.void
     KeyPool
       .Builder(
         (i: Int) => Ref.of[IO, Int](i),
@@ -101,8 +96,6 @@ class KeypoolSpec extends CatsEffectSuite {
   }
 
   test("Used Resource Cleaned Up By Reaper") {
-    def nothing(ref: Ref[IO, Int]): IO[Unit] =
-      ref.get.void
     KeyPool
       .Builder(
         (i: Int) => Ref.of[IO, Int](i),
@@ -128,9 +121,6 @@ class KeypoolSpec extends CatsEffectSuite {
   }
 
   test("Used Resource Not Cleaned Up if Idle Time has not expired") {
-    def nothing(ref: Ref[IO, Int]): IO[Unit] =
-      ref.get.void
-
     KeyPool
       .Builder(
         (i: Int) => Ref.of[IO, Int](i),
@@ -154,4 +144,33 @@ class KeypoolSpec extends CatsEffectSuite {
         } yield assert(init === 1 && later === 1)
       }
   }
+
+  test("Do not allocate more resources than the maxTotal") {
+    val MaxTotal = 10
+
+    KeyPool
+      .Builder(
+        (i: Int) => Ref.of[IO, Int](i),
+        nothing
+      )
+      .withMaxTotal(MaxTotal)
+      .build
+      .use { pool =>
+        for {
+          cdl <- CountDownLatch[IO](MaxTotal)
+          allocated <- IO.parReplicateAN(MaxTotal)(
+            MaxTotal,
+            pool.take(1).use(_ => cdl.release >> IO.never).start
+          )
+          _ <- cdl.await // make sure the pool is exhausted
+          attempt1 <- pool.take(1).use_.timeout(100.millis).attempt
+          _ <- allocated.traverse(_.cancel)
+          attempt2 <- pool.take(1).use_.timeout(100.millis).attempt
+        } yield assert(attempt1.isLeft && attempt2.isRight)
+      }
+  }
+
+  private def nothing(ref: Ref[IO, Int]): IO[Unit] =
+    ref.get.void
+
 }

--- a/core/src/test/scala/org/typelevel/keypool/PoolSpec.scala
+++ b/core/src/test/scala/org/typelevel/keypool/PoolSpec.scala
@@ -23,6 +23,7 @@ package org.typelevel.keypool
 
 import cats.syntax.all._
 import cats.effect._
+import cats.effect.std.CountDownLatch
 import scala.concurrent.duration._
 import munit.CatsEffectSuite
 import scala.concurrent.ExecutionContext
@@ -133,6 +134,31 @@ class PoolSpec extends CatsEffectSuite {
           _ <- Temporal[IO].sleep(6.seconds)
           later <- pool.state
         } yield assert(init.total === 1 && later.total === 1)
+      }
+  }
+
+  test("Do not allocate more resources than the maxTotal") {
+    val MaxTotal = 10
+
+    Pool
+      .Builder(
+        Ref.of[IO, Int](1),
+        nothing
+      )
+      .withMaxTotal(MaxTotal)
+      .build
+      .use { pool =>
+        for {
+          cdl <- CountDownLatch[IO](MaxTotal)
+          allocated <- IO.parReplicateAN(MaxTotal)(
+            MaxTotal,
+            pool.take.use(_ => cdl.release >> IO.never).start
+          )
+          _ <- cdl.await // make sure the pool is exhausted
+          attempt1 <- pool.take.use_.timeout(100.millis).attempt
+          _ <- allocated.traverse(_.cancel)
+          attempt2 <- pool.take.use_.timeout(100.millis).attempt
+        } yield assert(attempt1.isLeft && attempt2.isRight)
       }
   }
 


### PR DESCRIPTION
My attempt to fix #389.

I assume, `maxPerKey` should behave in the same way?

