### PR TITLE
Minor cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ ThisBuild / crossScalaVersions := Seq("2.12.15", Scala213, "3.0.2")
 ThisBuild / tlVersionIntroduced := Map("3" -> "0.4.3")
 ThisBuild / developers += tlGitHubDev("ChristopherDavenport", "Christopher Davenport")
 ThisBuild / startYear := Some(2019)
-ThisBuild / licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
+ThisBuild / licenses := Seq(License.MIT)
 ThisBuild / tlSiteApiUrl := Some(url("https://www.javadoc.io/doc/org.typelevel/keypool_2.12"))
 
 lazy val root = tlCrossRootProject.aggregate(core)

--- a/core/src/main/scala/org/typelevel/keypool/KeyPool.scala
+++ b/core/src/main/scala/org/typelevel/keypool/KeyPool.scala
@@ -23,6 +23,7 @@ package org.typelevel.keypool
 
 import cats._
 import cats.effect.kernel._
+import cats.effect.kernel.syntax.spawn._
 import cats.syntax.all._
 import scala.concurrent.duration._
 import org.typelevel.keypool.internal._
@@ -135,7 +136,7 @@ object KeyPool {
       kpVar: Ref[F, PoolMap[A, (B, F[Unit])]],
       onReaperException: Throwable => F[Unit]
   )(implicit F: Temporal[F]): F[Unit] = {
-    // We are going to do non-referentially tranpsarent things as we may be waiting for our modification to go through
+    // We are going to do non-referentially transparent things as we may be waiting for our modification to go through
     // which may change the state depending on when the modification block is running atomically at the moment
     def findStale(
         now: FiniteDuration,
@@ -151,6 +152,7 @@ object KeyPool {
       // ([resource] -> [resource]) ->
       // [(key, PoolList resource)] ->
       // (Map key (PoolList resource), [resource])
+      @annotation.tailrec
       def findStale_(
           toKeep: List[(A, PoolList[(B, F[Unit])])] => List[(A, PoolList[(B, F[Unit])])],
           toDestroy: List[(A, (B, F[Unit]))] => List[(A, (B, F[Unit]))],
@@ -163,7 +165,7 @@ object KeyPool {
             // when it is placed back into the pool.
             val (notStale, stale) = pList.toList.span(r => isNotStale(r._1))
             val toDestroy_ : List[(A, (B, F[Unit]))] => List[(A, (B, F[Unit]))] = l =>
-              toDestroy((stale.map(t => (key -> t._2)) ++ l))
+              toDestroy(stale.map(t => key -> t._2) ++ l)
             val toKeep_ : List[(A, PoolList[(B, F[Unit])])] => List[(A, PoolList[(B, F[Unit])])] =
               l =>
                 PoolList.fromList(notStale) match {
@@ -214,19 +216,19 @@ object KeyPool {
   private[keypool] def state[F[_]: Functor, A, B](
       kpVar: Ref[F, PoolMap[A, (B, F[Unit])]]
   ): F[(Int, Map[A, Int])] =
-    kpVar.get.map(pm =>
-      pm match {
-        case PoolClosed() => (0, Map.empty)
-        case PoolOpen(idleCount, m) =>
-          val modified = m.map { case (k, pl) =>
-            pl match {
-              case One(_, _) => (k, 1)
-              case Cons(_, length, _, _) => (k, length)
-            }
-          }.toMap
-          (idleCount, modified)
-      }
-    )
+    kpVar.get.map {
+      case PoolClosed() =>
+        (0, Map.empty)
+
+      case PoolOpen(idleCount, m) =>
+        val modified = m.map { case (k, pl) =>
+          pl match {
+            case One(_, _) => (k, 1)
+            case Cons(_, length, _, _) => (k, length)
+          }
+        }
+        (idleCount, modified)
+    }
 
   private[keypool] def put[F[_]: Temporal, A, B](
       kp: KeyPoolConcrete[F, A, B],
@@ -284,7 +286,7 @@ object KeyPool {
           m.get(k) match {
             case None => (pOrig, None)
             case Some(One(a, _)) =>
-              (PoolMap.open(idleCount - 1, m - (k)), Some(a))
+              (PoolMap.open(idleCount - 1, m - k), Some(a))
             case Some(Cons(a, _, _, rest)) =>
               (PoolMap.open(idleCount - 1, m + (k -> rest)), Some(a))
           }
@@ -363,9 +365,7 @@ object KeyPool {
         _ <- idleTimeAllowedInPool match {
           case fd: FiniteDuration =>
             val nanos = 0.seconds.max(fd)
-            Resource.make(
-              Concurrent[F].start(keepRunning(KeyPool.reap(nanos, kpVar, onReaperException)))
-            )(_.cancel)
+            keepRunning(KeyPool.reap(nanos, kpVar, onReaperException)).background.void
           case _ =>
             Applicative[Resource[F, *]].unit
         }

--- a/core/src/main/scala/org/typelevel/keypool/KeyPoolBuilder.scala
+++ b/core/src/main/scala/org/typelevel/keypool/KeyPoolBuilder.scala
@@ -25,6 +25,7 @@ import internal.{PoolList, PoolMap}
 import cats._
 import cats.syntax.all._
 import cats.effect.kernel._
+import cats.effect.kernel.syntax.spawn._
 import scala.concurrent.duration._
 
 @deprecated("use KeyPool.Builder", "0.4.7")
@@ -86,9 +87,7 @@ final class KeyPoolBuilder[F[_]: Temporal, A, B] private (
       _ <- idleTimeAllowedInPool match {
         case fd: FiniteDuration =>
           val nanos = 0.seconds.max(fd)
-          Resource.make(
-            Concurrent[F].start(keepRunning(KeyPool.reap(nanos, kpVar, onReaperException)))
-          )(_.cancel)
+          keepRunning(KeyPool.reap(nanos, kpVar, onReaperException)).background.void
         case _ =>
           Applicative[Resource[F, *]].unit
       }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
+val sbtTypelevelVersion = "0.4.11"
+
 addSbtPlugin("org.scala-js"     % "sbt-scalajs"               % "1.7.1")
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16")
-val sbtTypelevelVersion = "0.4.11"
-addSbtPlugin("org.typelevel" % "sbt-typelevel"      % sbtTypelevelVersion)
-addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % sbtTypelevelVersion)
+addSbtPlugin("org.typelevel"    % "sbt-typelevel"             % sbtTypelevelVersion)
+addSbtPlugin("org.typelevel"    % "sbt-typelevel-site"        % sbtTypelevelVersion)


### PR DESCRIPTION
This PR brings several minor improvements:
- Reorder dependencies in `plugins.sbt` for the sake of readability
- Fix typos
- Specify `@tailrec` annotation on recursive-friendly method
- Use `.background` syntax instead of `Resource.make(Concurrent[F].start(...))(_.cancel)`