### PR TITLE
Update Scala 3 version to `3.2.1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.17, 2.13.10, 3.1.3]
+        scala: [2.12.17, 2.13.10, 3.2.1]
         java: [temurin@8]
         project: [rootJS, rootJVM, rootNative]
     runs-on: ${{ matrix.os }}
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.1.3]
+        scala: [3.2.1]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -211,32 +211,32 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.1.3, rootJS)
+      - name: Download target directories (3.2.1, rootJS)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.3-rootJS
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.1-rootJS
 
-      - name: Inflate target directories (3.1.3, rootJS)
+      - name: Inflate target directories (3.2.1, rootJS)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.1.3, rootJVM)
+      - name: Download target directories (3.2.1, rootJVM)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.3-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.1-rootJVM
 
-      - name: Inflate target directories (3.1.3, rootJVM)
+      - name: Inflate target directories (3.2.1, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.1.3, rootNative)
+      - name: Download target directories (3.2.1, rootNative)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.3-rootNative
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.1-rootNative
 
-      - name: Inflate target directories (3.1.3, rootNative)
+      - name: Inflate target directories (3.2.1, rootNative)
         run: |
           tar xf targets.tar
           rm targets.tar
@@ -260,7 +260,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.1.3]
+        scala: [3.2.1]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,4 +1,0 @@
-updates.pin = [
-  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.1." },
-  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = "3.1." }
-]

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,10 @@
 import com.typesafe.tools.mima.core._
 
 val Scala213 = "2.13.10"
+val Scala3 = "3.2.1"
 
 ThisBuild / tlBaseVersion := "0.4"
-ThisBuild / crossScalaVersions := Seq("2.12.17", Scala213, "3.1.3")
+ThisBuild / crossScalaVersions := Seq("2.12.17", Scala213, Scala3)
 ThisBuild / tlVersionIntroduced := Map("3" -> "0.4.3")
 ThisBuild / developers += tlGitHubDev("ChristopherDavenport", "Christopher Davenport")
 ThisBuild / startYear := Some(2019)


### PR DESCRIPTION
Our upstream `cats` library has updated Scala 3 version to `3.2.1`, and almost all libraries under `typelevel` have done it too. So let's do the same.