### PR TITLE
Fix cancelation of taking from pool

### DIFF
--- a/core/src/test/scala/org/typelevel/keypool/KeyPoolSpec.scala
+++ b/core/src/test/scala/org/typelevel/keypool/KeyPoolSpec.scala
@@ -179,4 +179,12 @@ class KeyPoolSpec extends CatsEffectSuite {
   private def nothing(ref: Ref[IO, Int]): IO[Unit] =
     ref.get.void
 
+  test("Acquiring from pool is cancelable") {
+    TestControl.executeEmbed {
+      KeyPool.Builder((_: Unit) => Resource.eval(IO.never[Unit])).build.use { pool =>
+        pool.take(()).use_.timeoutTo(1.second, IO.unit)
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
When the pool has to freshly acquire a resource, this must be wrapped in `poll` so that it is cancelable.

h/t @balmungsan for reporting via an Ember client connect hang.