### PR TITLE
Add `durationBetweenEvictionRuns` configuration

### DIFF
--- a/core/src/main/scala/org/typelevel/keypool/KeyPoolBuilder.scala
+++ b/core/src/main/scala/org/typelevel/keypool/KeyPoolBuilder.scala
@@ -95,7 +95,10 @@ final class KeyPoolBuilder[F[_]: Temporal, A, B] private (
       _ <- idleTimeAllowedInPool match {
         case fd: FiniteDuration =>
           val nanos = 0.seconds.max(fd)
-          keepRunning(KeyPool.reap(nanos, kpVar, onReaperException)).background.void
+          val durationBetweenEvictionRuns = 5.seconds // the previous default
+          keepRunning(
+            KeyPool.reap(nanos, durationBetweenEvictionRuns, kpVar, onReaperException)
+          ).background.void
         case _ =>
           Applicative[Resource[F, *]].unit
       }

--- a/core/src/main/scala/org/typelevel/keypool/Pool.scala
+++ b/core/src/main/scala/org/typelevel/keypool/Pool.scala
@@ -74,6 +74,7 @@ object Pool {
       val kpRes: Resource[F, B],
       val kpDefaultReuseState: Reusable,
       val idleTimeAllowedInPool: Duration,
+      val durationBetweenEvictionRuns: Duration,
       val kpMaxIdle: Int,
       val kpMaxTotal: Int,
       val onReaperException: Throwable => F[Unit]
@@ -82,6 +83,7 @@ object Pool {
         kpRes: Resource[F, B] = this.kpRes,
         kpDefaultReuseState: Reusable = this.kpDefaultReuseState,
         idleTimeAllowedInPool: Duration = this.idleTimeAllowedInPool,
+        durationBetweenEvictionRuns: Duration = this.durationBetweenEvictionRuns,
         kpMaxIdle: Int = this.kpMaxIdle,
         kpMaxTotal: Int = this.kpMaxTotal,
         onReaperException: Throwable => F[Unit] = this.onReaperException
@@ -89,6 +91,7 @@ object Pool {
       kpRes,
       kpDefaultReuseState,
       idleTimeAllowedInPool,
+      durationBetweenEvictionRuns,
       kpMaxIdle,
       kpMaxTotal,
       onReaperException
@@ -108,6 +111,9 @@ object Pool {
     def withIdleTimeAllowedInPool(duration: Duration): Builder[F, B] =
       copy(idleTimeAllowedInPool = duration)
 
+    def withDurationBetweenEvictionRuns(duration: Duration): Builder[F, B] =
+      copy(durationBetweenEvictionRuns = duration)
+
     def withMaxIdle(maxIdle: Int): Builder[F, B] =
       copy(kpMaxIdle = maxIdle)
 
@@ -122,6 +128,7 @@ object Pool {
         kpRes = _ => kpRes,
         kpDefaultReuseState = kpDefaultReuseState,
         idleTimeAllowedInPool = idleTimeAllowedInPool,
+        durationBetweenEvictionRuns = durationBetweenEvictionRuns,
         kpMaxPerKey = _ => kpMaxTotal,
         kpMaxIdle = kpMaxIdle,
         kpMaxTotal = kpMaxTotal,
@@ -145,6 +152,7 @@ object Pool {
       res,
       Defaults.defaultReuseState,
       Defaults.idleTimeAllowedInPool,
+      Defaults.durationBetweenEvictionRuns,
       Defaults.maxIdle,
       Defaults.maxTotal,
       Defaults.onReaperException[F]
@@ -159,6 +167,7 @@ object Pool {
     private object Defaults {
       val defaultReuseState = Reusable.Reuse
       val idleTimeAllowedInPool = 30.seconds
+      val durationBetweenEvictionRuns = 5.seconds
       val maxIdle = 100
       val maxTotal = 100
       def onReaperException[F[_]: Applicative] = { (t: Throwable) =>


### PR DESCRIPTION
This adds a configuration for `durationBetweenEvictionRuns` a la commons-pool2. 
- following the documentation in commons-pool2, I have implemented it so that a negative duration or an infinite duration will disable the reaper thread entirely
- I have maintained the previous `5.seconds` constant in the deprecated `KeyPoolBuilder`

closes #556 