### PR TITLE
Add a `fairness` parameter

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -6,3 +6,8 @@ This software contains portions of code derived from http-client
 https://github.com/snoyberg/http-client
 Copyright (c) 2013 Michael Snoyman
 Licensed under MIT (see licenses/LICENSE_http-client)
+
+This software contains portions of code derived from cats-effect
+https://github.com/typelevel/cats-effect
+Copyright (c) 2020-2023 The Typelevel Cats-effect Project Developers
+Licensed under Apache License 2.0 (see licenses/LICENSE_cats-effect)

--- a/core/src/main/scala/org/typelevel/keypool/Fairness.scala
+++ b/core/src/main/scala/org/typelevel/keypool/Fairness.scala
@@ -27,7 +27,7 @@ package org.typelevel.keypool
  * Lifo will process requests in last-in-first-out order. Fifo will process requests in
  * first-in-first-out order.
  */
-sealed trait Fairness
+sealed trait Fairness extends Product with Serializable
 object Fairness {
   case object Lifo extends Fairness
   case object Fifo extends Fairness

--- a/core/src/main/scala/org/typelevel/keypool/Fairness.scala
+++ b/core/src/main/scala/org/typelevel/keypool/Fairness.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.typelevel.keypool
+
+sealed trait Fairness
+object Fairness {
+  case object Lifo extends Fairness
+  case object Fifo extends Fairness
+}

--- a/core/src/main/scala/org/typelevel/keypool/Fairness.scala
+++ b/core/src/main/scala/org/typelevel/keypool/Fairness.scala
@@ -21,6 +21,12 @@
 
 package org.typelevel.keypool
 
+/**
+ * Fairness defines the order in which pending requests acquire a connection from the pool.
+ *
+ * Lifo will process requests in last-in-first-out order. Fifo will process requests in
+ * first-in-first-out order.
+ */
 sealed trait Fairness
 object Fairness {
   case object Lifo extends Fairness

--- a/core/src/main/scala/org/typelevel/keypool/KeyPool.scala
+++ b/core/src/main/scala/org/typelevel/keypool/KeyPool.scala
@@ -385,10 +385,7 @@ object KeyPool {
         kpVar <- Resource.make(
           Ref[F].of[PoolMap[A, (B, F[Unit])]](PoolMap.open(0, Map.empty[A, PoolList[(B, F[Unit])]]))
         )(kpVar => KeyPool.destroy(kpVar))
-        kpMaxTotalSem <- fairness match {
-          case Fairness.Fifo => Resource.eval(RequestSemaphore[F](Fairness.Fifo, kpMaxTotal))
-          case Fairness.Lifo => Resource.eval(RequestSemaphore[F](Fairness.Lifo, kpMaxTotal))
-        }
+        kpMaxTotalSem <- Resource.eval(RequestSemaphore[F](fairness, kpMaxTotal))
         _ <- (idleTimeAllowedInPool, durationBetweenEvictionRuns) match {
           case (fdI: FiniteDuration, fdE: FiniteDuration) if fdE >= 0.seconds =>
             val idleNanos = 0.seconds.max(fdI)

--- a/core/src/main/scala/org/typelevel/keypool/KeyPoolBuilder.scala
+++ b/core/src/main/scala/org/typelevel/keypool/KeyPoolBuilder.scala
@@ -91,7 +91,7 @@ final class KeyPoolBuilder[F[_]: Temporal, A, B] private (
       kpVar <- Resource.make(
         Ref[F].of[PoolMap[A, (B, F[Unit])]](PoolMap.open(0, Map.empty[A, PoolList[(B, F[Unit])]]))
       )(kpVar => KeyPool.destroy(kpVar))
-      kpMaxTotalSem <- Resource.eval(RequestSemaphore[F](Fifo, kpMaxTotal))
+      kpMaxTotalSem <- Resource.eval(RequestSemaphore[F](Fairness.Fifo, kpMaxTotal))
       _ <- idleTimeAllowedInPool match {
         case fd: FiniteDuration =>
           val nanos = 0.seconds.max(fd)

--- a/core/src/main/scala/org/typelevel/keypool/KeyPoolBuilder.scala
+++ b/core/src/main/scala/org/typelevel/keypool/KeyPoolBuilder.scala
@@ -26,8 +26,8 @@ import cats._
 import cats.syntax.all._
 import cats.effect.kernel._
 import cats.effect.kernel.syntax.spawn._
-import cats.effect.std.Semaphore
 import scala.concurrent.duration._
+import org.typelevel.keypool.internal._
 
 @deprecated("use KeyPool.Builder", "0.4.7")
 final class KeyPoolBuilder[F[_]: Temporal, A, B] private (
@@ -91,7 +91,7 @@ final class KeyPoolBuilder[F[_]: Temporal, A, B] private (
       kpVar <- Resource.make(
         Ref[F].of[PoolMap[A, (B, F[Unit])]](PoolMap.open(0, Map.empty[A, PoolList[(B, F[Unit])]]))
       )(kpVar => KeyPool.destroy(kpVar))
-      kpMaxTotalSem <- Resource.eval(Semaphore[F](kpMaxTotal.toLong))
+      kpMaxTotalSem <- Resource.eval(RequestSemaphore[F](Fifo, kpMaxTotal))
       _ <- idleTimeAllowedInPool match {
         case fd: FiniteDuration =>
           val nanos = 0.seconds.max(fd)

--- a/core/src/main/scala/org/typelevel/keypool/Pool.scala
+++ b/core/src/main/scala/org/typelevel/keypool/Pool.scala
@@ -77,6 +77,7 @@ object Pool {
       val durationBetweenEvictionRuns: Duration,
       val kpMaxIdle: Int,
       val kpMaxTotal: Int,
+      val fairness: Boolean,
       val onReaperException: Throwable => F[Unit]
   ) {
     private def copy(
@@ -86,6 +87,7 @@ object Pool {
         durationBetweenEvictionRuns: Duration = this.durationBetweenEvictionRuns,
         kpMaxIdle: Int = this.kpMaxIdle,
         kpMaxTotal: Int = this.kpMaxTotal,
+        fairness: Boolean = this.fairness,
         onReaperException: Throwable => F[Unit] = this.onReaperException
     ): Builder[F, B] = new Builder[F, B](
       kpRes,
@@ -94,6 +96,7 @@ object Pool {
       durationBetweenEvictionRuns,
       kpMaxIdle,
       kpMaxTotal,
+      fairness,
       onReaperException
     )
 
@@ -120,6 +123,9 @@ object Pool {
     def withMaxTotal(total: Int): Builder[F, B] =
       copy(kpMaxTotal = total)
 
+    def withFairness(fairness: Boolean): Builder[F, B] =
+      copy(fairness = fairness)
+
     def withOnReaperException(f: Throwable => F[Unit]): Builder[F, B] =
       copy(onReaperException = f)
 
@@ -132,6 +138,7 @@ object Pool {
         kpMaxPerKey = _ => kpMaxTotal,
         kpMaxIdle = kpMaxIdle,
         kpMaxTotal = kpMaxTotal,
+        fairness = fairness,
         onReaperException = onReaperException
       )
 
@@ -155,6 +162,7 @@ object Pool {
       Defaults.durationBetweenEvictionRuns,
       Defaults.maxIdle,
       Defaults.maxTotal,
+      Defaults.fairness,
       Defaults.onReaperException[F]
     )
 
@@ -170,6 +178,7 @@ object Pool {
       val durationBetweenEvictionRuns = 5.seconds
       val maxIdle = 100
       val maxTotal = 100
+      val fairness = true // defaults to serve requests in Fifo order
       def onReaperException[F[_]: Applicative] = { (t: Throwable) =>
         Function.const(Applicative[F].unit)(t)
       }

--- a/core/src/main/scala/org/typelevel/keypool/Pool.scala
+++ b/core/src/main/scala/org/typelevel/keypool/Pool.scala
@@ -77,7 +77,7 @@ object Pool {
       val durationBetweenEvictionRuns: Duration,
       val kpMaxIdle: Int,
       val kpMaxTotal: Int,
-      val fairness: Boolean,
+      val fairness: Fairness,
       val onReaperException: Throwable => F[Unit]
   ) {
     private def copy(
@@ -87,7 +87,7 @@ object Pool {
         durationBetweenEvictionRuns: Duration = this.durationBetweenEvictionRuns,
         kpMaxIdle: Int = this.kpMaxIdle,
         kpMaxTotal: Int = this.kpMaxTotal,
-        fairness: Boolean = this.fairness,
+        fairness: Fairness = this.fairness,
         onReaperException: Throwable => F[Unit] = this.onReaperException
     ): Builder[F, B] = new Builder[F, B](
       kpRes,
@@ -123,7 +123,7 @@ object Pool {
     def withMaxTotal(total: Int): Builder[F, B] =
       copy(kpMaxTotal = total)
 
-    def withFairness(fairness: Boolean): Builder[F, B] =
+    def withFairness(fairness: Fairness): Builder[F, B] =
       copy(fairness = fairness)
 
     def withOnReaperException(f: Throwable => F[Unit]): Builder[F, B] =
@@ -178,7 +178,7 @@ object Pool {
       val durationBetweenEvictionRuns = 5.seconds
       val maxIdle = 100
       val maxTotal = 100
-      val fairness = true // defaults to serve requests in Fifo order
+      val fairness = Fairness.Fifo
       def onReaperException[F[_]: Applicative] = { (t: Throwable) =>
         Function.const(Applicative[F].unit)(t)
       }

--- a/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
+++ b/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
@@ -29,8 +29,15 @@ import scala.annotation.nowarn
 
 import org.typelevel.keypool.Fairness
 
-// Derived from cats-effect MiniSemaphore
-// https://github.com/typelevel/cats-effect/blob/v3.5.4/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala#L29
+/**
+ * RequestSemaphore moderates access to pooled connections by setting the number of permits
+ * available to the total number of connections. This is a custom semaphore implementation that only
+ * provides the `permit` operation. Additionally it takes a [[Fairness]] parameter, used to toggle
+ * the order in which requests acquire a permit.
+ *
+ * Derived from cats-effect MiniSemaphore
+ * https://github.com/typelevel/cats-effect/blob/v3.5.4/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala#L29
+ */
 private[keypool] abstract class RequestSemaphore[F[_]] {
   def permit: Resource[F, Unit]
 }

--- a/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
+++ b/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
@@ -104,10 +104,6 @@ private[keypool] object RequestSemaphore {
 
       def permit: Resource[F, Unit] =
         Resource.makeFull((poll: Poll[F]) => poll(acquire))(_ => release)
-
-      // def withPermit[A](fa: F[A]): F[A] = F.uncancelable { poll =>
-      //   poll(acquire) >> poll(fa).guarantee(release)
-      // }
     }
   }
 }

--- a/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
+++ b/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2019 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.typelevel.keypool.internal
+
+import cats.syntax.all._
+import cats.effect.kernel.syntax.all._
+import cats.effect.kernel._
+import scala.collection.immutable.{Queue => ScalaQueue}
+import scala.annotation.nowarn
+
+sealed trait Fairness
+case object Lifo extends Fairness
+case object Fifo extends Fairness
+
+// Derived from cats-effect MiniSemaphore
+// https://github.com/typelevel/cats-effect/blob/v3.5.4/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala#L29
+private[keypool] abstract class RequestSemaphore[F[_]] {
+  def permit: Resource[F, Unit]
+}
+
+private[keypool] object RequestSemaphore {
+  private trait BackingQueue[F[_], A] {
+    def cleanup(fa: F[A], elem: A): F[A]
+    def offer(fa: F[A], elem: A): F[A]
+    def take(fa: F[A]): (F[A], A)
+    def nonEmpty(fa: F[A]): Boolean
+  }
+
+  private implicit def listQueue[A <: AnyRef]: BackingQueue[List, A] = new BackingQueue[List, A] {
+    def cleanup(fa: List[A], elem: A) = fa.filterNot(_ eq elem)
+    def offer(fa: List[A], elem: A) = elem :: fa
+    def take(fa: List[A]) = (fa.tail, fa.head)
+    def nonEmpty(fa: List[A]) = fa.nonEmpty
+  }
+
+  private implicit def queueQueue[A <: AnyRef]: BackingQueue[ScalaQueue, A] =
+    new BackingQueue[ScalaQueue, A] {
+      def cleanup(fa: ScalaQueue[A], elem: A) = fa.filterNot(_ eq elem)
+      def offer(fa: ScalaQueue[A], elem: A) = fa :+ elem
+      def take(fa: ScalaQueue[A]) = (fa.tail, fa.head)
+      def nonEmpty(fa: ScalaQueue[A]) = fa.nonEmpty
+    }
+
+  private case class State[F[_], A](waiting: F[A], permits: Long)(implicit ev: BackingQueue[F, A])
+
+  def apply[F[_]](fairness: Fairness, n: Long)(implicit
+      F: GenConcurrent[F, _]
+  ): F[RequestSemaphore[F]] = {
+    require(n >= 0, s"n must be nonnegative, was: $n")
+
+    fairness match {
+      case Fifo => F.ref(State(ScalaQueue[Deferred[F, Unit]](), n)).map(semaphore(_))
+      case Lifo => F.ref(State(List.empty[Deferred[F, Unit]], n)).map(semaphore(_))
+    }
+  }
+
+  private def semaphore[F[_], G[_]](
+      state: Ref[F, State[G, Deferred[F, Unit]]]
+  )(implicit F: GenConcurrent[F, _], B: BackingQueue[G, Deferred[F, Unit]]): RequestSemaphore[F] = {
+    new RequestSemaphore[F] {
+      private def acquire: F[Unit] =
+        F.uncancelable { poll =>
+          F.deferred[Unit].flatMap { wait =>
+            val cleanup = state.update { case s @ State(waiting, permits) =>
+              if (B.nonEmpty(waiting))
+                State(B.cleanup(waiting, wait), permits)
+              else s
+            }
+
+            state.modify { case State(waiting, permits) =>
+              if (permits == 0) {
+                State(B.offer(waiting, wait), permits) -> poll(wait.get).onCancel(cleanup)
+              } else
+                State(waiting, permits - 1) -> ().pure[F]
+            }.flatten
+          }
+        }
+
+      private def release: F[Unit] =
+        state.flatModify { case State(waiting, permits) =>
+          if (B.nonEmpty(waiting)) {
+            val (rest, next) = B.take(waiting)
+            State(rest, permits) -> next.complete(()).void
+          } else
+            State(waiting, permits + 1) -> ().pure[F]
+        }
+
+      def permit: Resource[F, Unit] =
+        Resource.makeFull((poll: Poll[F]) => poll(acquire))(_ => release)
+
+      // def withPermit[A](fa: F[A]): F[A] = F.uncancelable { poll =>
+      //   poll(acquire) >> poll(fa).guarantee(release)
+      // }
+    }
+  }
+}

--- a/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
+++ b/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
@@ -60,7 +60,9 @@ private[keypool] object RequestSemaphore {
       def nonEmpty(fa: ScalaQueue[A]) = fa.nonEmpty
     }
 
-  private case class State[F[_], A](waiting: F[A], permits: Long)(implicit ev: BackingQueue[F, A])
+  private case class State[F[_], A](waiting: F[A], permits: Long)(implicit
+      @nowarn ev: BackingQueue[F, A]
+  )
 
   def apply[F[_]](fairness: Fairness, n: Long)(implicit
       F: GenConcurrent[F, _]

--- a/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
+++ b/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
@@ -62,14 +62,16 @@ private[keypool] object RequestSemaphore {
       @nowarn ev: BackingQueue[CC, A]
   )
 
-  def apply[F[_]](fairness: Fairness, n: Int)(implicit
+  def apply[F[_]](fairness: Fairness, numPermits: Int)(implicit
       F: GenConcurrent[F, _]
   ): F[RequestSemaphore[F]] = {
-    require(n >= 0, s"n must be nonnegative, was: $n")
+    require(numPermits >= 0, s"numPermits must be nonnegative, was: $numPermits")
 
     fairness match {
-      case Fairness.Fifo => F.ref(State(ScalaQueue.empty[Deferred[F, Unit]], n)).map(semaphore(_))
-      case Fairness.Lifo => F.ref(State(List.empty[Deferred[F, Unit]], n)).map(semaphore(_))
+      case Fairness.Fifo =>
+        F.ref(State(ScalaQueue.empty[Deferred[F, Unit]], numPermits)).map(semaphore(_))
+      case Fairness.Lifo =>
+        F.ref(State(List.empty[Deferred[F, Unit]], numPermits)).map(semaphore(_))
     }
   }
 

--- a/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
+++ b/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
@@ -68,7 +68,7 @@ private[keypool] object RequestSemaphore {
     require(n >= 0, s"n must be nonnegative, was: $n")
 
     fairness match {
-      case Fairness.Fifo => F.ref(State(ScalaQueue[Deferred[F, Unit]](), n)).map(semaphore(_))
+      case Fairness.Fifo => F.ref(State(ScalaQueue.empty[Deferred[F, Unit]], n)).map(semaphore(_))
       case Fairness.Lifo => F.ref(State(List.empty[Deferred[F, Unit]], n)).map(semaphore(_))
     }
   }

--- a/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
+++ b/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
@@ -27,9 +27,7 @@ import cats.effect.kernel._
 import scala.collection.immutable.{Queue => ScalaQueue}
 import scala.annotation.nowarn
 
-sealed trait Fairness
-case object Lifo extends Fairness
-case object Fifo extends Fairness
+import org.typelevel.keypool.Fairness
 
 // Derived from cats-effect MiniSemaphore
 // https://github.com/typelevel/cats-effect/blob/v3.5.4/kernel/shared/src/main/scala/cats/effect/kernel/MiniSemaphore.scala#L29
@@ -70,8 +68,8 @@ private[keypool] object RequestSemaphore {
     require(n >= 0, s"n must be nonnegative, was: $n")
 
     fairness match {
-      case Fifo => F.ref(State(ScalaQueue[Deferred[F, Unit]](), n)).map(semaphore(_))
-      case Lifo => F.ref(State(List.empty[Deferred[F, Unit]], n)).map(semaphore(_))
+      case Fairness.Fifo => F.ref(State(ScalaQueue[Deferred[F, Unit]](), n)).map(semaphore(_))
+      case Fairness.Lifo => F.ref(State(List.empty[Deferred[F, Unit]], n)).map(semaphore(_))
     }
   }
 

--- a/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
+++ b/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
@@ -60,11 +60,11 @@ private[keypool] object RequestSemaphore {
       def nonEmpty(fa: ScalaQueue[A]) = fa.nonEmpty
     }
 
-  private case class State[F[_], A](waiting: F[A], permits: Long)(implicit
+  private case class State[F[_], A](waiting: F[A], permits: Int)(implicit
       @nowarn ev: BackingQueue[F, A]
   )
 
-  def apply[F[_]](fairness: Fairness, n: Long)(implicit
+  def apply[F[_]](fairness: Fairness, n: Int)(implicit
       F: GenConcurrent[F, _]
   ): F[RequestSemaphore[F]] = {
     require(n >= 0, s"n must be nonnegative, was: $n")

--- a/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
+++ b/core/src/main/scala/org/typelevel/keypool/internal/RequestSemaphore.scala
@@ -92,7 +92,7 @@ private[keypool] object RequestSemaphore {
               if (permits == 0) {
                 State(B.offer(waiting, wait), permits) -> poll(wait.get).onCancel(cleanup)
               } else
-                State(waiting, permits - 1) -> ().pure[F]
+                State(waiting, permits - 1) -> F.unit
             }.flatten
           }
         }
@@ -103,7 +103,7 @@ private[keypool] object RequestSemaphore {
             val (rest, next) = B.take(waiting)
             State(rest, permits) -> next.complete(()).void
           } else
-            State(waiting, permits + 1) -> ().pure[F]
+            State(waiting, permits + 1) -> F.unit
         }
 
       def permit: Resource[F, Unit] =

--- a/core/src/test/scala/org/typelevel/keypool/KeyPoolSpec.scala
+++ b/core/src/test/scala/org/typelevel/keypool/KeyPoolSpec.scala
@@ -260,7 +260,7 @@ class KeyPoolSpec extends CatsEffectSuite {
           nothing
         )
         .withMaxTotal(1)
-        .withFairness(false)
+        .withFairness(Fairness.Lifo)
         .build
         .use { pool =>
           for {

--- a/core/src/test/scala/org/typelevel/keypool/PoolSpec.scala
+++ b/core/src/test/scala/org/typelevel/keypool/PoolSpec.scala
@@ -240,7 +240,7 @@ class PoolSpec extends CatsEffectSuite {
           nothing
         )
         .withMaxTotal(1)
-        .withFairness(false)
+        .withFairness(Fairness.Lifo)
         .build
         .use { pool =>
           for {

--- a/core/src/test/scala/org/typelevel/keypool/internal/RequestSemaphoreSpec.scala
+++ b/core/src/test/scala/org/typelevel/keypool/internal/RequestSemaphoreSpec.scala
@@ -81,10 +81,10 @@ class RequestSemaphoreSpec extends CatsEffectSuite {
       sem <- RequestSemaphore[IO](Fifo, 1)
       ref <- IO.ref(List.empty[Int])
       gate <- CountDownLatch[IO](4)
-      _ <- action(sem, ref, gate, 1).start *> IO.sleep(10.milli)
-      _ <- action(sem, ref, gate, 2).start *> IO.sleep(10.milli)
-      _ <- action(sem, ref, gate, 3).start *> IO.sleep(10.milli)
-      _ <- action(sem, ref, gate, 4).start *> IO.sleep(10.milli)
+      _ <- action(sem, ref, gate, 1).start *> IO.sleep(15.milli)
+      _ <- action(sem, ref, gate, 2).start *> IO.sleep(15.milli)
+      _ <- action(sem, ref, gate, 3).start *> IO.sleep(15.milli)
+      _ <- action(sem, ref, gate, 4).start
       _ <- gate.await // wait for all the actions to finish
       xs <- ref.get
     } yield xs
@@ -105,10 +105,10 @@ class RequestSemaphoreSpec extends CatsEffectSuite {
       sem <- RequestSemaphore[IO](Lifo, 1)
       ref <- IO.ref(List.empty[Int])
       gate <- CountDownLatch[IO](4)
-      _ <- action(sem, ref, gate, 1).start *> IO.sleep(10.milli)
-      _ <- action(sem, ref, gate, 2).start *> IO.sleep(10.milli)
-      _ <- action(sem, ref, gate, 3).start *> IO.sleep(10.milli)
-      _ <- action(sem, ref, gate, 4).start *> IO.sleep(10.milli)
+      _ <- action(sem, ref, gate, 1).start *> IO.sleep(15.milli)
+      _ <- action(sem, ref, gate, 2).start *> IO.sleep(15.milli)
+      _ <- action(sem, ref, gate, 3).start *> IO.sleep(15.milli)
+      _ <- action(sem, ref, gate, 4).start
       _ <- gate.await // wait for all the actions to finish
       xs <- ref.get
     } yield xs

--- a/core/src/test/scala/org/typelevel/keypool/internal/RequestSemaphoreSpec.scala
+++ b/core/src/test/scala/org/typelevel/keypool/internal/RequestSemaphoreSpec.scala
@@ -80,6 +80,7 @@ class RequestSemaphoreSpec extends CatsEffectSuite {
       _ <- IO.sleep(10.milli)
       _ <- f2.cancel // cancel before acquiring
       _ <- f1.cancel
+      _ <- sem.permit.surround(IO.unit)
       r <- ref.get
     } yield r
     assertIO(r, 0)

--- a/core/src/test/scala/org/typelevel/keypool/internal/RequestSemaphoreSpec.scala
+++ b/core/src/test/scala/org/typelevel/keypool/internal/RequestSemaphoreSpec.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2019 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.typelevel.keypool.internal
+
+import munit.CatsEffectSuite
+import cats.effect._
+import cats.effect.std.CountDownLatch
+import scala.concurrent.duration._
+
+class RequestSemaphoreSpec extends CatsEffectSuite {
+
+  test("throw if permits is negative") {
+    interceptIO[IllegalArgumentException](IO.defer(RequestSemaphore[IO](Fifo, -1)))
+  }
+
+  test("acquire permit and execute action") {
+    val b = RequestSemaphore[IO](Fifo, 1).flatMap { sem =>
+      sem.permit.surround(IO.pure(true))
+    }
+    assertIOBoolean(b)
+  }
+
+  test("block if no permits are available") {
+    val time = for {
+      sem <- RequestSemaphore[IO](Fifo, 1)
+      _ <- sem.permit.surround(IO.sleep(3.second)).start *> IO.sleep(10.milli)
+      t <- sem.permit.surround(IO.unit).timed
+    } yield t
+    assertIOBoolean(time.map { case (t, _) => t > 2.seconds })
+  }
+
+  test("release the permit if action errors") {
+    val b = for {
+      sem <- RequestSemaphore[IO](Fifo, 1)
+      _ <- sem.permit.surround(IO.raiseError(new Exception("honk"))).attempt
+      b <- sem.permit.surround(IO.pure(true))
+    } yield b
+    assertIOBoolean(b)
+  }
+
+  test("release the permit if action cancelled") {
+    val b = for {
+      sem <- RequestSemaphore[IO](Fifo, 1)
+      fiber <- sem.permit.surround(IO.never).start
+      _ <- IO.sleep(10.milli)
+      _ <- fiber.cancel
+      b <- sem.permit.surround(IO.pure(true))
+    } yield b
+    assertIOBoolean(b)
+  }
+
+  test("acquire permits in FIFO order") {
+    def action(
+        sem: RequestSemaphore[IO],
+        ref: Ref[IO, List[Int]],
+        gate: CountDownLatch[IO],
+        id: Int
+    ): IO[Unit] =
+      sem.permit.surround(ref.update(xs => xs :+ id) *> IO.sleep(1.second) *> gate.release)
+
+    val r = for {
+      sem <- RequestSemaphore[IO](Fifo, 1)
+      ref <- IO.ref(List.empty[Int])
+      gate <- CountDownLatch[IO](4)
+      _ <- action(sem, ref, gate, 1).start *> IO.sleep(10.milli)
+      _ <- action(sem, ref, gate, 2).start *> IO.sleep(10.milli)
+      _ <- action(sem, ref, gate, 3).start *> IO.sleep(10.milli)
+      _ <- action(sem, ref, gate, 4).start *> IO.sleep(10.milli)
+      _ <- gate.await // wait for all the actions to finish
+      xs <- ref.get
+    } yield xs
+
+    assertIO(r, List(1, 2, 3, 4))
+  }
+
+  test("acquire permits in LIFO order") {
+    def action(
+        sem: RequestSemaphore[IO],
+        ref: Ref[IO, List[Int]],
+        gate: CountDownLatch[IO],
+        id: Int
+    ): IO[Unit] =
+      sem.permit.surround(ref.update(xs => xs :+ id) *> IO.sleep(1.second) *> gate.release)
+
+    val r = for {
+      sem <- RequestSemaphore[IO](Lifo, 1)
+      ref <- IO.ref(List.empty[Int])
+      gate <- CountDownLatch[IO](4)
+      _ <- action(sem, ref, gate, 1).start *> IO.sleep(10.milli)
+      _ <- action(sem, ref, gate, 2).start *> IO.sleep(10.milli)
+      _ <- action(sem, ref, gate, 3).start *> IO.sleep(10.milli)
+      _ <- action(sem, ref, gate, 4).start *> IO.sleep(10.milli)
+      _ <- gate.await // wait for all the actions to finish
+      xs <- ref.get
+    } yield xs
+
+    assertIO(r, List(1, 4, 3, 2))
+  }
+
+}

--- a/core/src/test/scala/org/typelevel/keypool/internal/RequestSemaphoreSpec.scala
+++ b/core/src/test/scala/org/typelevel/keypool/internal/RequestSemaphoreSpec.scala
@@ -24,8 +24,9 @@ package org.typelevel.keypool.internal
 import munit.CatsEffectSuite
 import cats.effect._
 import cats.effect.testkit.TestControl
-
 import scala.concurrent.duration._
+
+import org.typelevel.keypool.Fairness._
 
 class RequestSemaphoreSpec extends CatsEffectSuite {
 

--- a/licenses/LICENSE_cats-effect
+++ b/licenses/LICENSE_cats-effect
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS


### PR DESCRIPTION
`KeyPool` and `Pool` now support a `fairness` parameter that controls how incoming requests are handled. 
When `fairness` is true requests are served in FIFO order, and when `fairness` is false requests are served in LIFO order. 

The default value here is true, **this is the opposite of commons-pool2** but it maintains consistency for people using keypool so I think it's the correct choice. 

The behaviour switch is handled by a custom semaphore that we're using now, instead of the existing cats-effect semaphore. That semaphore has a `BackingQueue` that can switch behaviour between FIFO and LIFO (this is toggled using the fairness parameter) 
